### PR TITLE
Update plugin and MP dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 [![License](https://img.shields.io/badge/License-ASL%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)
 
-# application-stack-samples
+# devfile-stack-samples
 Samples repository showing use of java-openliberty devfile-based application stack.
 
-See https://github.com/OpenLiberty/application-stack/blob/master/README.md for getting started info
+See https://github.com/OpenLiberty/devfile-stack/blob/main/README.md for getting started info

--- a/devfiles/gradle-image/README.md
+++ b/devfiles/gradle-image/README.md
@@ -24,7 +24,7 @@ The provided devfile allows you to start developing your gradle built applicatio
 cd <your project root dir>
 ```
 ```
-$ curl -L https://raw.githubusercontent.com/OpenLiberty/application-stack-samples/main/devfiles/gradle-image/devfile.yaml -o devfile.yaml  
+$ curl -L https://raw.githubusercontent.com/OpenLiberty/devfile-stack-samples/main/devfiles/gradle-image/devfile.yaml -o devfile.yaml  
 ```
 
 2. Create your application component.

--- a/devfiles/m2-repo-volume/README.md
+++ b/devfiles/m2-repo-volume/README.md
@@ -25,7 +25,7 @@ Sample devfile for creating and mounting a persistent volume to use as the Maven
 cd <your project root dir>
 ```
 ```
-$ curl -L https://raw.githubusercontent.com/OpenLiberty/application-stack-samples/main/devfiles/m2-repo-volume/devfile.yaml -o devfile.yaml  
+$ curl -L https://raw.githubusercontent.com/OpenLiberty/devfile-stack-samples/main/devfiles/m2-repo-volume/devfile.yaml -o devfile.yaml  
 ```
 
 2. Create your application component.

--- a/devfiles/m2-repo-volume/devfile.yaml
+++ b/devfiles/m2-repo-volume/devfile.yaml
@@ -19,7 +19,7 @@ metadata:
   name: java-ol-m2-volume
   description: Java application devfile using a volume to store the maven m2 cache
 parent:
-  uri: "https://github.com/OpenLiberty/application-stack/releases/download/maven-0.7.0/devfile.yaml"
+  uri: "https://github.com/OpenLiberty/devfile-stack/releases/download/maven-0.7.0/devfile.yaml"
   components:
     - name: dev
       container:

--- a/devfiles/maven-image/README.md
+++ b/devfiles/maven-image/README.md
@@ -24,7 +24,7 @@ The provided devfile allows you to start developing your maven built application
 cd <your project root dir>
 ```
 ```
-$ curl -L https://raw.githubusercontent.com/OpenLiberty/application-stack-samples/main/devfiles/maven-image/devfile.yaml -o devfile.yaml  
+$ curl -L https://raw.githubusercontent.com/OpenLiberty/devfile-stack-samples/main/devfiles/maven-image/devfile.yaml -o devfile.yaml  
 ```
 
 2. Create your application component.

--- a/devfiles/maven-image/devfile.yaml
+++ b/devfiles/maven-image/devfile.yaml
@@ -23,7 +23,7 @@ starterProjects:
   - name: user-app
     git:
       remotes:
-        origin: 'https://github.com/OpenLiberty/application-stack-starters.git'
+        origin: 'https://github.com/OpenLiberty/devfile-stack-starters.git'
 components:
   - name: dev
     container:

--- a/jpa/README-minikube.md
+++ b/jpa/README-minikube.md
@@ -107,7 +107,7 @@ minikube addons enable olm
 ```
 
 ### Installing odo
-Please follow the installation instructions outlined in the [odo](https://odo.dev) documentation to install the latest odo CLI (version 2.2.4+).
+Please follow the installation instructions outlined in the [odo](https://odo.dev) documentation to install the latest odo CLI (version 2.4.0+).
 
 ## Actions to Perform by Users in 2 Roles
 
@@ -118,73 +118,37 @@ In this example there are 2 roles:
 
 ### Cluster Admin
 
-The cluster admin needs to install 2 Operators into the cluster:
+The cluster admin needs to install the backing service operator into the cluster.
 
-* Service Binding Operator (version 0.9.1+)
-* A Backing Service Operator
-
-A Backing Service Operator that is "bind-able," in other
-words a Backing Service Operator that exposes binding information in secrets, config maps, status, and/or spec
-attributes. The Backing Service Operator may represent a database or other services required by
-applications. We'll use Dev4Devs PostgreSQL Operator found in the OperatorHub to
-demonstrate a sample use case.
-
-#### Installing the Service Binding Operator
-
-Below `kubectl` command will make the Service Binding Operator available in all namespaces on your minikube:
-```shell
-kubectl create -f https://operatorhub.io/install/service-binding-operator.yaml
-```
+A backing service operator is an operator that represents a database or any other services required by the application. 
+In order to bound to the application, it needs to expose binding information in secrets, config maps, status, and/or spec
+attributes. We'll use Dev4Devs PostgreSQL Operator found in the OperatorHub to demonstrate a sample use case.
 
 #### Installing the DB operator
 
 Below `kubectl` command will make the PostgreSQL Operator available in `my-postgresql-operator-dev4devs-com` namespace of your minikube cluster:
+
 ```shell
 kubectl create -f https://operatorhub.io/install/postgresql-operator-dev4devs-com.yaml
 ```
 **NOTE**: This Operator will be installed in the "my-postgresql-operator-dev4devs-com" namespace and will be usable from this namespace only.
 
-#### Providing Service Resource Access to the Service Binding Operator
-
-Starting with v0.10.0, the Service Binding Operator, requires explicit permissions to access service resources.
-
-Create a ClusterRole resource.
-
-```shell
-cat <<EOF | kubectl apply -f-
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: sbo-service-view
-  labels:
-    service.binding/controller: "true"
-rules:
-  - apiGroups:
-      - postgresql.dev4devs.com
-    resources:
-      - databases
-    verbs:
-      - get
-      - list
-EOF
-```
-
 ### Application Developer
 
 #### Importing the demo Java MicroService JPA application
 
-In this example we will use odo to manage a sample [Java MicroServices JPA application](https://github.com/OpenLiberty/application-stack-samples.git).
+In this example we will use odo to manage a sample [Java MicroServices JPA application](https://github.com/OpenLiberty/devfile-stack-samples.git).
 
 1. Clone the sample app repo to your system.
 
 ```shell
-git clone https://github.com/OpenLiberty/application-stack-samples.git
+git clone https://github.com/OpenLiberty/devfile-stack-samples.git
 ```
 
 2. `cd` to the sample JPA application.
 
 ```shell
-cd ./application-stack-samples/jpa
+cd ./devfile-stack-samples/jpa
 ```
 
 3. Create a Java Open Liberty component.
@@ -267,7 +231,6 @@ odo catalog list services
 Services available through Operators
 NAME                                CRDs
 postgresql-operator.v0.1.1          Backup, Database
-service-binding-operator.v0.9.1     ServiceBinding, ServiceBinding
 ```
 
 2. Generate the yaml config of the Database service provided by the postgresql-operator.v0.1.1 operator and store it in a file.
@@ -298,7 +261,7 @@ metadata:
     service.binding/db_user: 'path={.spec.databaseUser}'
 ```
 
-Adding the annotations ensures that the Service Binding Operator will inject the `databaseName`, `databasePassword` and `databaseUser` spec values into the application. Note that the instance name you configure will be used as part of the name of various artifacts and resource references. Be sure to change it.
+Adding the annotations ensures that odo will inject the `databaseName`, `databasePassword` and `databaseUser` spec values into the application. Note that the instance name you configure will be used as part of the name of various artifacts and resource references. Be sure to change it.
 
 4. Generate the Database service devfile configuration.
 

--- a/jpa/build.gradle
+++ b/jpa/build.gradle
@@ -18,7 +18,7 @@ configurations {
 }
 
 dependencies {
-    providedCompile 'org.eclipse.microprofile:microprofile:4.0.1'
+    providedCompile 'org.eclipse.microprofile:microprofile:4.1'
     providedCompile 'jakarta.platform:jakarta.jakartaee-api:8.0.0'
     postgresql 'org.postgresql:postgresql:42.2.23'
     testImplementation 'org.slf4j:slf4j-log4j12:1.7.31'
@@ -35,7 +35,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.2.1'
+        classpath 'io.openliberty.tools:liberty-gradle-plugin:3.3'
     }
 }
 

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -43,7 +43,7 @@
         <liberty.var.default.http.port>9080</liberty.var.default.http.port>
         <liberty.var.default.https.port>9443</liberty.var.default.https.port>
         <liberty.var.app.path>/api</liberty.var.app.path>
-        <version.liberty-maven-plugin>3.4</version.liberty-maven-plugin>
+        <version.liberty-maven-plugin>3.5</version.liberty-maven-plugin>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>4.0.1</version>
+            <version>4.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
@@ -138,7 +138,7 @@
                     <stripVersion>true</stripVersion>
                     <serverStartTimeout>360</serverStartTimeout>
                     <copyDependencies>
-                        <location>${project.build.directory}/liberty/wlp/usr/shared/resources</location>
+                        <location>/opt/ol/wlp/usr/shared/resources</location>
                         <dependency>
                             <groupId>mysql</groupId>
                             <artifactId>mysql-connector-java</artifactId>

--- a/jpa/src/main/liberty/config/server.xml
+++ b/jpa/src/main/liberty/config/server.xml
@@ -20,7 +20,7 @@
     <feature>jpa-2.2</feature>
     <feature>jdbc-4.3</feature>
     <feature>jsf-2.3</feature>
-    <feature>mpHealth-3.0</feature>
+    <feature>mpHealth-3.1</feature>
   </featureManager>
 
    <include optional="true" location="${server.config.dir}/postgresql-ds.xml"/>


### PR DESCRIPTION
This PR updates:
- MP and OL plugin versions used.
- Updates references of application-stack with devfile-stack.
- Fixes a bug where the database related libraries were not being copied to the correct Liberty installation location. This is a fall out from the change in Liberty driver installation location. Note that the updated JPA sample is currently an OL specific sample; therefore, the update is OL specific.